### PR TITLE
Fix _get_gpu_mem reserved memory

### DIFF
--- a/cg2all/lib/libmodel.py
+++ b/cg2all/lib/libmodel.py
@@ -129,7 +129,7 @@ CONFIG["structure_module"] = STRUCTURE_MODULE
 def _get_gpu_mem():
     return (
         torch.cuda.memory_allocated() / 1024 / 1024,
-        torch.cuda.memory_allocated() / 1024 / 1024,
+        torch.cuda.memory_reserved() / 1024 / 1024,
     )
 
 


### PR DESCRIPTION
## Summary
- fix `_get_gpu_mem` to return reserved GPU memory instead of allocated twice

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842362dc6fc8322a0a827f0e4d633b9