### PR TITLE
Remove Martini2 model option

### DIFF
--- a/cg2all/script/convert_all2cg.py
+++ b/cg2all/script/convert_all2cg.py
@@ -43,7 +43,7 @@ def main():
         cg_model = cg2all.lib.libcg.CalphaBasedModel
     elif arg.cg_model in ["RES", "res", "ResidueBasedModel"]:
         cg_model = cg2all.lib.libcg.ResidueBasedModel
-    elif arg.cg_model in ["Martini", "martini", "Martini2", "martini2"]:
+    elif arg.cg_model in ["Martini", "martini"]:
         cg_model = functools.partial(
             cg2all.lib.libcg.Martini, topology_map=read_coarse_grained_topology("martini")
         )

--- a/cg2all/script/convert_cg2all.py
+++ b/cg2all/script/convert_cg2all.py
@@ -47,7 +47,7 @@ def main():
         # fmt:off
         choices=["CalphaBasedModel", "CA", "ca", \
                 "ResidueBasedModel", "RES", "res", \
-                "Martini", "martini", "Martini2", "martini2", \
+                "Martini", "martini", \
                 "Martini3", "martini3", \
                 "PRIMO", "primo", \
                 "BB", "bb", "backbone", "Backbone", "BackboneModel", \
@@ -88,7 +88,7 @@ def main():
                 model_type = "CalphaBasedModel"
             elif arg.cg_model in ["ResidueBasedModel", "RES", "res"]:
                 model_type = "ResidueBasedModel"
-            elif arg.cg_model in ["Martini", "martini", "Martini2", "martini2"]:
+            elif arg.cg_model in ["Martini", "martini"]:
                 model_type = "Martini"
             elif arg.cg_model in ["Martini3", "martini3"]:
                 model_type = "Martini3"


### PR DESCRIPTION
## Summary
- drop `Martini2`/`martini2` from supported options in `convert_cg2all.py`
- drop `Martini2`/`martini2` from supported options in `convert_all2cg.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68423636b1788322a8243f8aadd140c6